### PR TITLE
RSS章节 笔误

### DIFF
--- a/network/RSS.md
+++ b/network/RSS.md
@@ -47,7 +47,7 @@ Other:		0
 Combined:	4
 ```
 
-可以看到硬件最多支持 6 个，当前使用了 4 个。将 RX/TX 队列数量都设为 8。
+可以看到硬件最多支持 8 个，当前使用了 4 个。将 RX/TX 队列数量都设为 8。
 ```plain
 $ ethtool -L eth0 combined 8
 ```


### PR DESCRIPTION
硬件最多支持 6 个 按命令输出应为 8 个