### PR TITLE
chore: add missing devDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "vuepress": "2.0.0-rc.0",
     "vuepress-plugin-comment2": "2.0.0-rc.4",
     "vuepress-plugin-md-enhance": "2.0.0-rc.4",
-    "vuepress-plugin-reading-time2": "2.0.0-rc.4"
+    "vuepress-plugin-reading-time2": "2.0.0-rc.4",
+    "@vuepress/plugin-container": "2.0.0-rc.0"
   },
   "dependencies": {
     "vue-github-button": "3.1.0"


### PR DESCRIPTION
add missing devDep "@vuepress/plugin-container"

```
> vuepress build .

Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@vuepress/plugin-container' imported from /dev/github/theByteBook/.vuepress/config.js.6e78e0a6.mjs
Did you mean to import @vuepress+plugin-container@2.0.0-rc.0/node_modules/@vuepress/plugin-container/lib/node/index.js?
    at new NodeError (node:internal/errors:405:5)
    at packageResolve (node:internal/modules/esm/resolve:916:9)
    at moduleResolve (node:internal/modules/esm/resolve:973:20)
    at defaultResolve (node:internal/modules/esm/resolve:1206:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:404:12)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:373:25)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:250:38)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:76:39)
    at link (node:internal/modules/esm/module_job:75:36)
```